### PR TITLE
Fix the wrong completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ And also, GEP has some awesome features already, you can directly use it!
 
 Make sure you have GDB 8.0 or higher compiled with Python3.7+ bindings, then:
 
-1. Install fzf: [Installation](https://github.com/junegunn/fzf#installation)
-
-2. Install this plug-in by:
+1. Install git and curl (or wget)
+2. Install fzf: [Installation](https://github.com/junegunn/fzf#installation) (Optional, but GEP works better with fzf)
+3. Install this plug-in by:
 
 ```shell
 # via the install script

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ ignore =
     # line break before binary operator (default)
     W503,
     # doc line too long (82 > 79 characters) (default)
-    W505
+    W505,
+    # whitespace before ':'
+    E203
 
 max-line-length = 100


### PR DESCRIPTION
This commit fixes the following case:
```
(gdb) complete b B
b build_charclass.isra
b foo::B::func()
```

With the old implementation, the completion of `b B<tab>` will be `b Build_charclass.isra` and `b Boo::B::func()`.
This is wrong, the correct completion should be `b build_charclass.isra` and `b foo::B::func()`.

This commit also fixes the following case:
```
(gdb) complete b 'm
...
b main'
(gdb) complete p 'm
...
b 'main
```

The completion of `b 'm<tab>` will be `b 'min'`, and the completion of `p 'm<tab>` will be `p 'main` (missing a single quote).
This is wrong, the correct completion should be `b 'main'` and `p 'main'`.

----

This PR should probably resolve #14 