### PR TITLE
Remove the config about using ctrl-c to quit gdb

### DIFF
--- a/gdbinit-gep
+++ b/gdbinit-gep
@@ -14,7 +14,3 @@ set history remove-duplicates unlimited
 # Set whether to use single column for tab completion
 # defulat: on
 # set single-column-tab-complete off
-
-# Set whether to use ctrl-c to exit the gdb
-# defulat: off
-# set ctrl-c-quit on

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -359,10 +359,6 @@ class UserParamater(gdb.Parameter):
         return "%s is %r." % (self.set_show_doc.capitalize(), svalue)
 
 
-ctrl_c_quit = UserParamater(
-    "ctrl-c-quit", False, "whether to use ctrl-c to exit the gdb", gdb.PARAM_BOOLEAN
-)
-
 single_column_tab_complete = UserParamater(
     "single-column-tab-complete",
     True,
@@ -552,8 +548,7 @@ except gdb.error as e: print(e)
 """
                 )
         except KeyboardInterrupt:
-            if ctrl_c_quit.value:
-                gdb.execute("quit")
+            pass
         except EOFError:
             gdb.execute("quit")
         except Exception as e:


### PR DESCRIPTION
This is a bad design actually, I never enabled it after I created this config.