### PR TITLE
Update gdbinit-gep.py with [TAB] and [BTAB] for fzf list navigation

### DIFF
--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -75,7 +75,7 @@ FZF_RUN_CMD = (
     "fzf",
     "--select-1",
     "--bind=tab:down",
-    "--bind=btab:up",    
+    "--bind=btab:up",
     "--exit-0",
     "--tiebreak=index",
     "--no-multi",

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -74,6 +74,8 @@ DONT_REPEAT: set[str] = {
 FZF_RUN_CMD = (
     "fzf",
     "--select-1",
+    "--bind=tab:down",
+    "--bind=btab:up",    
     "--exit-0",
     "--tiebreak=index",
     "--no-multi",


### PR DESCRIPTION
I thought this was a nice change, it kind of goes in line with the feeling of tab completion where you can use tab and shift+tab to navigate up and down through fzf lists.