### PR TITLE
Add daily scheduled runs to build, lint, and test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       - '**'
       - '!*.md'
 
+  schedule:
+    - cron: '0 1 * * *'
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ on:
       - '**'
       - '!*.md'
 
+  schedule:
+    - cron: '0 1 * * *'
+
 jobs:
   lint:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ on:
       - '**'
       - '!*.md'
 
+  schedule:
+    - cron: '0 1 * * *'
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Docker Build ${{ matrix.images }}
-      run: docker-compose build ${{ matrix.images }}
+      run: docker compose build ${{ matrix.images }}
 
     - name: Test on ${{ matrix.images }}
-      run: docker-compose run ${{ matrix.images }} ./tests.sh
+      run: docker compose run ${{ matrix.images }} ./tests.sh


### PR DESCRIPTION
This pull request introduces a new scheduled workflow to the GitHub Actions configuration for the repository.
The changes involve adding a cron schedule to run the workflows daily at UTC+8 9:00 AM.
