### PR TITLE
Support portable pwndbg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,4 @@ COPY . /root/.local/share/GEP
 
 WORKDIR /root/.local/share/GEP
 
-RUN ./install.sh -d && \
-    uv sync --group dev
+RUN ./install.sh --dev

--- a/README.md
+++ b/README.md
@@ -46,7 +46,21 @@ git clone --depth 1 https://github.com/lebr0nli/GEP.git ~/.local/share/GEP
 5. Enjoy!
 
 > [!IMPORTANT]
-> After the installation, the script will automatically add `source /path/to/GEP/gdbinit-gep.py` to your `~/.gdbinit` file. Please make sure this line is **always** in your `~/.gdbinit` file during future modifications of your `~/.gdbinit`. Otherwise, you need to manually source it via CLI options (See the [GDB documentation](https://sourceware.org/gdb/onlinedocs/gdb/Initialization-Files.html) for more information).
+> After the installation, the script will automatically add `source /path/to/GEP/gdbinit-gep.py` to your `~/.gdbinit` file if `--skip-gdbinit` is not specified for `install.sh` script.
+> Please make sure this line is **always** in your `~/.gdbinit` file during future modifications of your `~/.gdbinit`. Otherwise, you need to manually source it via CLI options (See the [GDB documentation](https://sourceware.org/gdb/onlinedocs/gdb/Initialization-Files.html) for more information).
+
+<details>
+  <summary>For the users of portable pwndbg</summary>
+
+After you installed pwndbg, you can just run the following command to install GEP:
+
+```shell
+# You could also choose other directories to install GEP if you want
+git clone --depth 1 https://github.com/lebr0nli/GEP.git ~/.local/share/GEP
+~/.local/share/GEP/install.sh --skip-venv
+```
+
+</details>
 
 ## How to update the version of GEP?
 

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -22,13 +22,19 @@ import gdb
 directory, file = os.path.split(__file__)
 directory = os.path.expanduser(directory)
 directory = os.path.abspath(directory)
-sys.path.append(directory)
 venv_path = os.path.join(directory, ".venv")
-if not os.path.exists(venv_path):
-    print("You might need to reinstall GEP, please check the latest version on Github")
-    sys.exit(1)
-site_pkgs_path = glob(os.path.join(venv_path, "lib/*/site-packages"))[0]
-site.addsitedir(site_pkgs_path)
+if os.path.exists(venv_path):
+    sys.path.append(directory)
+    site_pkgs_path = glob(os.path.join(venv_path, "lib/*/site-packages"))[0]
+    site.addsitedir(site_pkgs_path)
+else:
+    try:
+        import prompt_toolkit
+
+        del prompt_toolkit
+    except ImportError:
+        print("Failed to find prompt_toolkit and venv is not found")
+        sys.exit(1)
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit import print_formatted_text

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ if [[ $SKIP_GDBINIT == 1 ]]; then
 else
     if ! grep -q '^[^#]*source.*/gdbinit-gep.py' ~/.gdbinit; then
         echo "Appending GEP to ~/.gdbinit"
-        printf '\n# Please make sure the following line is always the last in this file\n' >> ~/.gdbinit
+        printf '\n# Comment out the following line to disable GEP\n' >> ~/.gdbinit
         printf 'source %s\n' "$GDBINIT_GEP_PY" >> ~/.gdbinit
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -6,15 +6,15 @@ help_and_exit() {
     echo "Usage: $0 [-d|--dev]"
     cat << EOF
   -d,  --dev         install development dependencies
+  --skip-venv        skip creating virtualenv
+  --skip-gdbinit     do not set up gdbinit
 EOF
     exit 1
 }
 
-if [[ $# -gt 1 ]]; then
-    help_and_exit
-fi
-
 DEV=0
+SKIP_VENV=0
+SKIP_GDBINIT=0
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -22,7 +22,16 @@ while [[ $# -gt 0 ]]; do
             DEV=1
             shift
             ;;
+        --skip-venv)
+            SKIP_VENV=1
+            shift
+            ;;
+        --skip-gdbinit)
+            SKIP_GDBINIT=1
+            shift
+            ;;
         *)
+            echo "Unknown option: $1"
             help_and_exit
             ;;
     esac
@@ -33,35 +42,45 @@ GEP_BASE=$(pwd)
 GDBINIT_GEP_PY=$GEP_BASE/gdbinit-gep.py
 echo "GEP installation path: $GEP_BASE"
 
-# find python path
-PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.python_version_tuple()[:2]))')
-PYTHON=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
-if ! uname -a | grep -q Darwin > /dev/null; then
-    PYTHON+="${PYVER}"
-fi
-
-# create venv and install prompt_toolkit
-VENV_PATH=$GEP_BASE/.venv
-echo "Creating virtualenv in path: ${VENV_PATH}"
-"$PYTHON" -m venv "$VENV_PATH"
-PYTHON=$VENV_PATH/bin/python
-echo "Installing dependencies"
-"$PYTHON" -m pip install -U pip
 if [[ $DEV == 1 ]]; then
     uv sync --group dev
 else
-    "$VENV_PATH/bin/pip" install --no-cache-dir -e .
+    if [[ $SKIP_VENV == 1 ]]; then
+        echo "Skipping virtualenv creation"
+    else
+        # find python path
+        PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.python_version_tuple()[:2]))')
+        PYTHON=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
+        if ! uname -a | grep -q Darwin > /dev/null; then
+            PYTHON+="${PYVER}"
+        fi
+        # create venv and install prompt_toolkit
+        VENV_PATH=$GEP_BASE/.venv
+        echo "Creating virtualenv in path: ${VENV_PATH}"
+        "$PYTHON" -m venv "$VENV_PATH"
+        PYTHON=$VENV_PATH/bin/python
+        echo "Installing dependencies"
+        "$PYTHON" -m pip install -U pip
+        "$VENV_PATH/bin/pip" install --no-cache-dir -e .
+    fi
 fi
 
 # copy example config to GEP_BASE if not exists
 echo "Copying default config to $GEP_BASE if not exists"
-cp -n "$GEP_BASE"/example/* "$GEP_BASE"
+# Note: macOS will return 1 if the file already exists
+cp -n "$GEP_BASE"/example/* "$GEP_BASE" || true
 
 # append GEP to gdbinit if not exists
-if ! grep -q '^[^#]*source.*/gdbinit-gep.py' ~/.gdbinit; then
-    echo "Appending GEP to ~/.gdbinit"
-    printf '\n# Please make sure the following line is always the last in this file\n' >> ~/.gdbinit
-    printf 'source %s\n' "$GDBINIT_GEP_PY" >> ~/.gdbinit
+if [[ $SKIP_GDBINIT == 1 ]]; then
+    echo "Skipping gdbinit setup"
+else
+    if ! grep -q '^[^#]*source.*/gdbinit-gep.py' ~/.gdbinit; then
+        echo "Appending GEP to ~/.gdbinit"
+        printf '\n# Please make sure the following line is always the last in this file\n' >> ~/.gdbinit
+        printf 'source %s\n' "$GDBINIT_GEP_PY" >> ~/.gdbinit
+    fi
 fi
+
+echo "Installation complete!"
 
 exit 0


### PR DESCRIPTION
This PR introduces several important changes to the installation and setup process of GEP.
The changes focus on adding new options for skipping the creation of `venv` (`--skip-venv`) and updating `~/.gdbinit` (`--skip-gdbinit`).  
Moreover, `venv` is now optional for running GEP.  

With these changes, users of the portable version of pwndbg should be able to use GEP without issues.