### PR TITLE
Make `show commands` work like vanilla GDB

### DIFF
--- a/example/gdbinit-gep
+++ b/example/gdbinit-gep
@@ -2,7 +2,8 @@
 set history save on
 
 # ignore duplicates
-set history remove-duplicates unlimited
+# Note: This option might have side effects: https://github.com/pwndbg/pwndbg/issues/2831
+# set history remove-duplicates unlimited
 
 # save all GDB histories to a same place (For example, ~/.gdb_history)
 # set history filename ~/.gdb_history

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -63,7 +63,6 @@ from prompt_toolkit.shortcuts import CompleteStyle
 
 # global variables
 HAS_FZF = which("fzf") is not None
-HISTORY_FILENAME = ".gdb_history"
 MULTI_LINE_COMMANDS = {"commands", "if", "while", "py", "python", "define", "document"}
 # This sucks, but there's not a GDB API for checking dont-repeat now.
 # I just collect some common used commands which should not be repeated.
@@ -328,18 +327,12 @@ def fzf_reverse_search(event: KeyPressEvent) -> None:
         # so user can see the original prompt while selecting completions, which is more user-friendly
         event.app.renderer.render(event.app, event.app.layout, is_done=True)
 
-        if not os.path.exists(HISTORY_FILENAME):
-            # just create an empty file
-            with open(HISTORY_FILENAME, "w"):
-                pass
         p = create_fzf_process(event.app.current_buffer.document.text_before_cursor)
-        with open(HISTORY_FILENAME) as f:
-            visited = set()
-            # Reverse the history, and only keep the youngest and unique one
-            for line in f.read().strip().split("\n")[::-1]:
-                if line and line not in visited:
-                    visited.add(line)
-                    p.stdin.write(line + "\n")  # ty: ignore[possibly-missing-attribute]
+        visited = set()
+        for cmd in reversed(event.app.current_buffer.history.get_strings()):
+            if cmd and cmd not in visited:
+                visited.add(cmd)
+                p.stdin.write(cmd + "\n")  # ty: ignore[possibly-missing-attribute]
         stdout, _ = p.communicate()
         if stdout:
             event.app.current_buffer.document = Document()  # clear buffer

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -816,8 +816,7 @@ class GDBCommandsHistory(History):
     def __init__(self) -> None:
         super().__init__()
         self._commands: list[str] = self.load_history_file()
-        if len(self._commands) > self.max_size:
-            self._commands = self._commands[-self.max_size :]
+        self._trim_to_max_size()
         atexit.register(self.dump_history_file)
         # Make prompt_toolkit happy
         self._loaded = True
@@ -833,10 +832,7 @@ class GDBCommandsHistory(History):
 
     @property
     def max_size(self) -> int:
-        size = T.cast(int, gdb.parameter("history size"))
-        if size == -1:
-            return 0xFFFFFFFF
-        return size
+        return T.cast(int, gdb.parameter("history size"))
 
     @property
     def remove_duplicates(self) -> int:
@@ -845,6 +841,17 @@ class GDBCommandsHistory(History):
     @property
     def commands(self) -> list[str]:
         return self._commands.copy()
+
+    def _trim_to_max_size(self) -> None:
+        max_size = self.max_size
+        if max_size == 0:
+            self._commands.clear()
+            return
+        elif max_size < 0:
+            # This means unlimited history size
+            return
+        elif len(self._commands) > max_size:
+            self._commands = self._commands[-max_size:]
 
     def load_history_file(self) -> list[str]:
         if not self.filename:
@@ -886,8 +893,7 @@ class GDBCommandsHistory(History):
                     break
 
         self._commands.append(string)
-        if len(self._commands) > self.max_size:
-            self._commands = self._commands[-self.max_size :]
+        self._trim_to_max_size()
         # Make prompt_toolkit happy
         self._loaded_strings = self._commands[::-1]
 

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -854,25 +854,28 @@ class GDBCommandsHistory(History):
             self._commands = self._commands[-max_size:]
 
     def load_history_file(self) -> list[str]:
-        if not self.filename:
+        filename = self.filename
+        if not filename:
             return []
         saved_commands = []
-        if os.path.exists(self.filename):
-            with open(self.filename) as f:
+        if os.path.exists(filename):
+            with open(filename) as f:
                 for command in f.read().splitlines():
                     if command:
                         saved_commands.append(command)
         return saved_commands
 
     def dump_history_file(self) -> None:
-        if not self.should_save:
+        should_save = self.should_save
+        if not should_save:
             return
-        if not self.filename:
+        filename = self.filename
+        if not filename:
             return
-        dirpath = os.path.dirname(self.filename)
+        dirpath = os.path.dirname(filename)
         if dirpath:
             os.makedirs(dirpath, exist_ok=True)
-        with open(self.filename, "w") as f:
+        with open(filename, "w") as f:
             for cmd in self._commands:
                 f.write(cmd + "\n")
 

--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -56,9 +56,7 @@ from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.formatted_text import FormattedText
-from prompt_toolkit.history import FileHistory
 from prompt_toolkit.history import History
-from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.key_binding import KeyPressEvent
 from prompt_toolkit.output import create_output
 from prompt_toolkit.shortcuts import CompleteStyle
@@ -817,29 +815,126 @@ else:
     print_warning("Install fzf for better experience with GEP")
 
 
-class GDBHistory(FileHistory):
+class GDBCommandsHistory(History):
     """
     Manage your GDB History
     """
 
-    def __init__(self, filename: str, ignore_duplicates: bool = False) -> None:
-        self.ignore_duplicates = ignore_duplicates
-        super().__init__(filename=filename)
+    def __init__(self) -> None:
+        super().__init__()
+        self._commands: list[str] = self.load_history_file()
+        if len(self._commands) > self.max_size:
+            self._commands = self._commands[-self.max_size :]
+        atexit.register(self.dump_history_file)
+        # Make prompt_toolkit happy
+        self._loaded = True
+        self._loaded_strings = self._commands[::-1]
 
-    def load_history_strings(self) -> list[str]:
-        strings = []
+    @property
+    def filename(self) -> str:
+        return T.cast(str, gdb.parameter("history filename"))
+
+    @property
+    def should_save(self) -> bool:
+        return T.cast(bool, gdb.parameter("history save"))
+
+    @property
+    def max_size(self) -> int:
+        size = T.cast(int, gdb.parameter("history size"))
+        if size == -1:
+            return 0xFFFFFFFF
+        return size
+
+    @property
+    def remove_duplicates(self) -> int:
+        return T.cast(int, gdb.parameter("history remove-duplicates"))
+
+    @property
+    def commands(self) -> list[str]:
+        return self._commands.copy()
+
+    def load_history_file(self) -> list[str]:
+        if not self.filename:
+            return []
+        saved_commands = []
         if os.path.exists(self.filename):
             with open(self.filename) as f:
-                for string in reversed(f.read().splitlines()):
-                    if self.ignore_duplicates and string in strings:
-                        continue
-                    if string:
-                        strings.append(string)
-        return strings
+                for command in f.read().splitlines():
+                    if command:
+                        saved_commands.append(command)
+        return saved_commands
+
+    def dump_history_file(self) -> None:
+        if not self.should_save:
+            return
+        if not self.filename:
+            return
+        dirpath = os.path.dirname(self.filename)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
+        with open(self.filename, "w") as f:
+            for cmd in self._commands:
+                f.write(cmd + "\n")
+
+    def load_history_strings(self) -> T.Iterable[str]:
+        yield from reversed(self._commands)
+
+    def append_string(self, string: str) -> None:
+        # We will handle the append logic by ourselves
+        pass
 
     def store_string(self, string: str) -> None:
-        with open(self.filename, "a") as f:
-            f.write(string.strip() + "\n")
+        removal = self.remove_duplicates
+        if removal != 0:
+            stop_idx = max(0, len(self._commands) - removal) if removal > 0 else 0
+            for idx in range(len(self._commands) - 1, stop_idx - 1, -1):
+                if self._commands[idx] == string:
+                    del self._commands[idx]
+                    break
+
+        self._commands.append(string)
+        if len(self._commands) > self.max_size:
+            self._commands = self._commands[-self.max_size :]
+        # Make prompt_toolkit happy
+        self._loaded_strings = self._commands[::-1]
+
+
+class ShowCommands(gdb.Command):
+    """Show the history of commands you typed.
+    You can supply a command number to start with, or a '+' to start after
+    the previous command number shown.
+    """
+
+    HIST_PRINT = 10
+
+    def __init__(self, history: GDBCommandsHistory) -> None:
+        super().__init__("show commands", gdb.COMMAND_NONE)
+        self._history = history
+        self._next_offset = 0
+
+    def invoke(self, argument: str, from_tty: bool) -> None:
+        commands = self._history.commands
+        argument = argument.strip()
+
+        if not argument:
+            start = len(commands) - self.HIST_PRINT
+        elif argument == "+":
+            start = self._next_offset
+        else:
+            try:
+                start = int(argument) - 1 - self.HIST_PRINT // 2
+            except ValueError:
+                raise gdb.GdbError(f"Invalid argument: {argument!r}")
+
+        if len(commands) - start < self.HIST_PRINT:
+            start = len(commands) - self.HIST_PRINT
+        start = max(0, start)
+        end = min(start + self.HIST_PRINT, len(commands))
+
+        for i in range(start, end):
+            print(f"{i + 1:5d}  {commands[i]}")
+
+        self._next_offset = end
 
 
 class GDBCompleter(Completer):
@@ -927,9 +1022,11 @@ def emulate_prompt(session: PromptSession, current_prompt: str, gdb_history: His
     full_cmd = session.prompt(ANSI(current_prompt.replace("\001", "").replace("\002", "")))
     main_cmd = re.split(r"\W+", full_cmd.strip())[0]
     quit_input_in_multiline_mode = False
+    is_repeat = False
 
     if not full_cmd.strip():
         full_cmd = get_repeat_command(gdb_history)
+        is_repeat = True
     elif main_cmd in MULTI_LINE_COMMANDS:
 
         def single_line_py(main_cmd: str, full_cmd: str) -> bool:
@@ -969,6 +1066,9 @@ def emulate_prompt(session: PromptSession, current_prompt: str, gdb_history: His
                 full_cmd += new_line
 
     if not quit_input_in_multiline_mode:
+        if not is_repeat:
+            # Update command history
+            gdb_history.store_string(full_cmd)
         # This is a hack to fix the issue when debugging the kernel with qemu-system-*
         # Without this hack, somehow pressing ctrl-c in GDB will not interrupt the kernel
         # See #23 for more details
@@ -984,15 +1084,8 @@ except gdb.error as e: print(e)
 def gep_prompt(current_prompt: str) -> None:
     print_info("GEP is running now!")
     UserParameter.gep_loaded = True
-    history_on = gdb.parameter("history save")
-    if history_on:
-        global HISTORY_FILENAME
-        HISTORY_FILENAME = T.cast(str, gdb.parameter("history filename"))
-        is_ignore_duplicates = -1 == gdb.parameter("history remove-duplicates")
-        gdb_history = GDBHistory(HISTORY_FILENAME, ignore_duplicates=is_ignore_duplicates)
-    else:
-        print_warning("`set history save on` for better experience with GEP")
-        gdb_history = InMemoryHistory()
+    gdb_history = GDBCommandsHistory()
+    ShowCommands(gdb_history)
     session: PromptSession = PromptSession(
         history=gdb_history,
         enable_history_search=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,27 +146,36 @@ class GDBSession:
 
     def stop(self) -> None:
         """
+        Kill the tmux session.
+
+        :return: None
+        """
+        if not self.__session_started:
+            return
+        pid = subprocess.check_output(
+            [
+                "tmux",
+                "list-panes",
+                "-t",
+                self.session_name,
+                "-F",
+                "#{pane_pid}",
+            ],
+            text=True,
+        ).strip()
+        if pid:
+            os.kill(int(pid), signal.SIGTERM)
+        subprocess.run(["tmux", "kill-session", "-t", self.session_name])
+        self.__session_started = False
+
+    def exit(self) -> None:
+        """
         Remove the temporary directory and stop the GDB session.
 
         :return: None
         """
+        self.stop()
         self.tmpdir.cleanup()
-        if self.__session_started:
-            pid = subprocess.check_output(
-                [
-                    "tmux",
-                    "list-panes",
-                    "-t",
-                    self.session_name,
-                    "-F",
-                    "#{pane_pid}",
-                ],
-                text=True,
-            ).strip()
-            if pid:
-                os.kill(int(pid), signal.SIGTERM)
-            subprocess.run(["tmux", "kill-session", "-t", self.session_name])
-            self.__session_started = False
 
     def check_session_started(func: T.Callable) -> T.Callable:
         """
@@ -238,7 +247,7 @@ class GDBSession:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        self.stop()
+        self.exit()
 
 
 @pytest.fixture

--- a/tests/test_commands_history.py
+++ b/tests/test_commands_history.py
@@ -1,0 +1,295 @@
+import re
+from pathlib import Path
+
+from conftest import GDB_HISTORY_NAME
+from conftest import GDBSession
+
+
+def _numbered_command(number: int, command: str) -> bytes:
+    return f"{number:5d}  {command}".encode()
+
+
+def _history_output_lines(pane_content: bytes) -> list[bytes]:
+    return [line for line in pane_content.splitlines() if re.match(rb"\s+\d+\s{2}", line)]
+
+
+def test_show_commands_shows_last_ten_commands(gdb_session: GDBSession) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 10)])
+
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(1, 10):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(10, "show commands") in pane_content
+
+
+def test_show_commands_shows_less_than_ten_commands(gdb_session: GDBSession) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 5)])
+
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 5
+    for i in range(1, 5):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(5, "show commands") in pane_content
+
+
+def test_show_commands_shows_ten_commands_with_offset(gdb_session: GDBSession) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 26)])
+
+    gdb_session.send_literal("show commands 10")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    # Should show 5~14 + show commands (total 10 commands)
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(5, 15):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    gdb_session.clear_pane()
+
+
+def test_show_commands_shows_ten_commands_when_offset_near_total(
+    gdb_session: GDBSession,
+) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 26)])
+
+    gdb_session.send_literal("show commands 25")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(17, 26):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(26, "show commands 25") in pane_content
+
+
+def test_show_commands_shows_less_than_ten_commands_with_offset(gdb_session: GDBSession) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 8)])
+
+    gdb_session.send_literal("show commands 5")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    # Should show 1~7 + show commands (total 8 commands)
+    assert len(_history_output_lines(pane_content)) == 8
+    for i in range(1, 8):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(8, "show commands 5") in pane_content
+
+
+def test_show_commands_plus_continues_after_previous_window(
+    gdb_session: GDBSession,
+) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 26)])
+
+    gdb_session.send_literal("show commands 10")
+    gdb_session.send_key("Enter")
+    gdb_session.clear_pane()
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands +")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(15, 25):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(25, "print 25") not in pane_content
+    assert _numbered_command(27, "show commands +") not in pane_content
+
+
+def test_show_commands_plus_starts_from_beginning_without_previous_window(
+    gdb_session: GDBSession,
+) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 26)])
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands +")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(1, 11):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(26, "show commands +") not in pane_content
+
+
+def test_show_commands_plus_shows_last_window_after_reaching_history_end(
+    gdb_session: GDBSession,
+) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 26)])
+
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    gdb_session.clear_pane()
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands +")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(18, 26):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(26, "show commands") in pane_content
+    assert _numbered_command(27, "show commands +") in pane_content
+
+
+def test_show_commands_plus_keeps_last_window_after_repeated_history_end(
+    gdb_session: GDBSession,
+) -> None:
+    gdb_session.start(histories=[f"print {i}" for i in range(1, 26)])
+
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    gdb_session.clear_pane()
+
+    gdb_session.send_literal("show commands +")
+    gdb_session.send_key("Enter")
+    gdb_session.clear_pane()
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands +")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(19, 26):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(26, "show commands") in pane_content
+    assert _numbered_command(27, "show commands +") in pane_content
+    assert _numbered_command(28, "show commands +") in pane_content
+
+
+def test_show_commands_without_remove_duplicates(gdb_session: GDBSession) -> None:
+    gdb_session.start(gdb_args=["-ex", "set history remove-duplicates 0"])
+
+    gdb_session.send_literal("print 1")
+    gdb_session.send_key("Enter")
+    gdb_session.send_literal("print 2")
+    gdb_session.send_key("Enter")
+    gdb_session.send_literal("print 2")
+    gdb_session.send_key("Enter")
+    gdb_session.send_literal("print 1")
+    gdb_session.send_key("Enter")
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 5
+    assert _numbered_command(1, "print 1") in pane_content
+    assert _numbered_command(2, "print 2") in pane_content
+    assert _numbered_command(3, "print 2") in pane_content
+    assert _numbered_command(4, "print 1") in pane_content
+    assert _numbered_command(5, "show commands") in pane_content
+
+
+def test_show_commands_with_remove_duplicates_5(gdb_session: GDBSession) -> None:
+    gdb_session.start(gdb_args=["-ex", "set history remove-duplicates 5"])
+
+    for i in range(1, 7):
+        gdb_session.send_literal(f"print {i}")
+        gdb_session.send_key("Enter")
+
+    # "print 1" should not be removed
+    # 1 -> (2 -> 3 -> 4 -> 5 -> 6)
+    gdb_session.send_literal("print 1")
+    gdb_session.send_key("Enter")
+
+    # "print 3" will be removed and append to the end
+    # 1 -> 2 -> (3 -> 4 -> 5 -> 6 -> 1)
+    gdb_session.send_literal("print 3")
+    gdb_session.send_key("Enter")
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    # After: 1 -> 2 -> 4 -> 5 -> 6 -> 1 -> 3 -> "show commands"
+    assert len(_history_output_lines(pane_content)) == 8
+    assert _numbered_command(1, "print 1") in pane_content
+    assert _numbered_command(2, "print 2") in pane_content
+    assert _numbered_command(3, "print 4") in pane_content
+    assert _numbered_command(4, "print 5") in pane_content
+    assert _numbered_command(5, "print 6") in pane_content
+    assert _numbered_command(6, "print 1") in pane_content
+    assert _numbered_command(7, "print 3") in pane_content
+    assert _numbered_command(8, "show commands") in pane_content
+
+
+def test_show_commands_with_remove_duplicates_unlimited(gdb_session: GDBSession) -> None:
+    gdb_session.start(gdb_args=["-ex", "set history remove-duplicates unlimited"])
+
+    gdb_session.send_literal("print 1")
+    gdb_session.send_key("Enter")
+    gdb_session.send_literal("print 2")
+    gdb_session.send_key("Enter")
+    gdb_session.send_literal("print 1")
+    gdb_session.send_key("Enter")
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 3
+    assert _numbered_command(1, "print 2") in pane_content
+    assert _numbered_command(2, "print 1") in pane_content
+    assert _numbered_command(3, "show commands") in pane_content
+
+
+def test_history_save_on() -> None:
+    gdb_session = GDBSession()
+    gdb_session.start(
+        gdb_args=["-ex", "set history save on"], histories=[f"print {i}" for i in range(1, 4)]
+    )
+    gdb_session.send_literal("print 4")
+    gdb_session.send_key("Enter")
+
+    gdb_session.stop()
+    new_history = (Path(gdb_session.tmpdir.name) / GDB_HISTORY_NAME).read_text().splitlines()
+    gdb_session.exit()
+
+    # History should be updated
+    assert len(new_history) == 4
+    assert new_history[0] == "print 1"
+    assert new_history[1] == "print 2"
+    assert new_history[2] == "print 3"
+    assert new_history[3] == "print 4"
+
+
+def test_history_save_off() -> None:
+    gdb_session = GDBSession()
+    gdb_session.start(
+        gdb_args=["-ex", "set history save off"], histories=[f"print {i}" for i in range(1, 4)]
+    )
+    gdb_session.send_literal("print 4")
+    gdb_session.send_key("Enter")
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 5
+    for i in range(1, 5):
+        assert _numbered_command(i, f"print {i}") in pane_content
+    assert _numbered_command(5, "show commands") in pane_content
+
+    gdb_session.stop()
+    new_history = (Path(gdb_session.tmpdir.name) / GDB_HISTORY_NAME).read_text().splitlines()
+    gdb_session.exit()
+
+    # History should not be updated
+    assert len(new_history) == 3
+    assert new_history[0] == "print 1"
+    assert new_history[1] == "print 2"
+    assert new_history[2] == "print 3"


### PR DESCRIPTION
This PR aligns `show commands` with vanilla GDB's behavior, so other plugins relying on it can correctly detect repeated commands, except when `history remove-duplicates` is set to a non-zero value.

----

- Before:
<img width="1447" height="651" alt="image" src="https://github.com/user-attachments/assets/8e194cfd-b5c7-404d-94eb-ee6be5be5bf8" />
<img width="1447" height="615" alt="image" src="https://github.com/user-attachments/assets/d2006486-a7aa-4335-9482-f777c796b935?" />


----

- After:
<img width="1446" height="715" alt="image" src="https://github.com/user-attachments/assets/0bf1d56a-4d59-48db-97d5-393307e26f35?" />
<img width="1452" height="656" alt="image" src="https://github.com/user-attachments/assets/b9d56fe9-0a0b-4b5e-ae9a-34b29c7d0d1c?" />

