### PR TITLE
Fix `show commands` numbering after history truncation

### DIFF
--- a/gdbinit-gep.py
+++ b/gdbinit-gep.py
@@ -815,12 +815,17 @@ class GDBCommandsHistory(History):
 
     def __init__(self) -> None:
         super().__init__()
+        self._base_num = 1
         self._commands: list[str] = self.load_history_file()
         self._trim_to_max_size()
         atexit.register(self.dump_history_file)
         # Make prompt_toolkit happy
         self._loaded = True
         self._loaded_strings = self._commands[::-1]
+
+    @property
+    def base_num(self) -> int:
+        return self._base_num
 
     @property
     def filename(self) -> str:
@@ -845,12 +850,14 @@ class GDBCommandsHistory(History):
     def _trim_to_max_size(self) -> None:
         max_size = self.max_size
         if max_size == 0:
+            self._base_num += len(self._commands)
             self._commands.clear()
             return
         elif max_size < 0:
             # This means unlimited history size
             return
         elif len(self._commands) > max_size:
+            self._base_num += len(self._commands) - max_size
             self._commands = self._commands[-max_size:]
 
     def load_history_file(self) -> list[str]:
@@ -916,6 +923,7 @@ class ShowCommands(gdb.Command):
 
     def invoke(self, argument: str, from_tty: bool) -> None:
         commands = self._history.commands
+        base_num = self._history.base_num
         argument = argument.strip()
 
         if not argument:
@@ -924,7 +932,7 @@ class ShowCommands(gdb.Command):
             start = self._next_offset
         else:
             try:
-                start = int(argument) - 1 - self.HIST_PRINT // 2
+                start = int(argument) - base_num - self.HIST_PRINT // 2
             except ValueError:
                 raise gdb.GdbError(f"Invalid argument: {argument!r}")
 
@@ -934,7 +942,7 @@ class ShowCommands(gdb.Command):
         end = min(start + self.HIST_PRINT, len(commands))
 
         for i in range(start, end):
-            print(f"{i + 1:5d}  {commands[i]}")
+            print(f"{i + base_num:5d}  {commands[i]}")
 
         self._next_offset = end
 

--- a/tests/test_commands_history.py
+++ b/tests/test_commands_history.py
@@ -293,3 +293,44 @@ def test_history_save_off() -> None:
     assert new_history[0] == "print 1"
     assert new_history[1] == "print 2"
     assert new_history[2] == "print 3"
+
+
+def test_truncation_of_loaded_history(gdb_session: GDBSession) -> None:
+    history_size = 256
+    gdb_session.start(
+        gdb_args=["-ex", f"set history size {history_size}"],
+        histories=[f"print {i}" for i in range(1, history_size + 1)],
+    )
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands 1")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(2, 12):
+        assert _numbered_command(i, f"print {i}") in pane_content
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands 1")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(3, 13):
+        assert _numbered_command(i, f"print {i}") in pane_content
+
+    gdb_session.clear_pane()
+    gdb_session.send_literal("show commands")
+    gdb_session.send_key("Enter")
+    pane_content = gdb_session.capture_pane()
+
+    current_max = history_size + 3
+    assert len(_history_output_lines(pane_content)) == 10
+    for i in range(current_max, current_max - 10, -1):
+        if i == current_max:
+            assert _numbered_command(i, "show commands") in pane_content
+        elif i == current_max - 1 or i == current_max - 2:
+            assert _numbered_command(i, "show commands 1") in pane_content
+        else:
+            assert _numbered_command(i, f"print {i}") in pane_content


### PR DESCRIPTION
This PR should resolve #82 

<img width="1451" height="870" alt="image" src="https://github.com/user-attachments/assets/7ed203ce-b217-426d-9f19-cf0f1dd93ace" />
