### PR TITLE
Improve host development and test infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,23 +23,26 @@ jobs:
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build
       run: |
-        sudo apt-get update && sudo apt-get install -y git gdb python3 python3-pip python3-venv tmux
-        git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-        ~/.fzf/install --all
-        ./install.sh
+        nix develop -c ./install.sh --uv
 
     - name: Check GEP is running normally
       run: |
-        gdb --version
-        export PATH=~/.fzf/bin:$PATH
-        tmux new-session -d -s check gdb -q
-        sleep 5
-        OUTPUT=$(tmux capture-pane -p -t check)
-        echo $OUTPUT
-        grep -q "GEP is running" <(echo "$OUTPUT")
-        ! grep -q "Install fzf for better experience with GEP" <(echo "$OUTPUT")
+        nix develop -c bash -lc '
+          gdb --version
+          tmux new-session -d -s check gdb -q
+          sleep 5
+          OUTPUT=$(tmux capture-pane -p -t check)
+          tmux kill-session -t check
+          echo "$OUTPUT"
+          grep -q "GEP is running" <(echo "$OUTPUT")
+          ! grep -q "Install fzf for better experience with GEP" <(echo "$OUTPUT")
+        '

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,15 +21,17 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install dependencies
       run: |
-        sudo apt-get update && sudo apt-get install -y shellcheck shfmt
-        curl -LsSf https://astral.sh/uv/0.5.14/install.sh | sh
-        ~/.local/bin/uv sync --group dev
+        nix develop -c uv sync --group dev
 
     - name: Run linters
       run: |
-        ./lint.sh
+        nix develop -c ./lint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,38 @@
-ARG image
+ARG image=ubuntu:24.04
 FROM $image
+
+ARG ZIG_VERSION=0.16.0
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates \
     python3 \
     python3-pip \
     python3-venv \
     tmux \
     git \
     gdb \
-    gcc \
     make \
     curl \
     wget \
+    xz-utils \
     vim && \
     git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && \
     ~/.fzf/install --all
 
-ENV PATH="/root/.fzf/bin:/root/.local/bin:${PATH}"
+RUN set -eux; \
+    case "$(uname -m)" in \
+        x86_64) zig_arch=x86_64-linux ;; \
+        aarch64) zig_arch=aarch64-linux ;; \
+        *) echo "Unsupported Zig host architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zig_arch}-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz; \
+    mkdir -p /opt/zig; \
+    tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; \
+    rm /tmp/zig.tar.xz; \
+    /opt/zig/zig version
+
+ENV PATH="/opt/zig:/root/.fzf/bin:/root/.local/bin:${PATH}"
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.13 /uv /bin/
 

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,22 +1,37 @@
 FROM archlinux:latest
 
+ARG ZIG_VERSION=0.16.0
+
 RUN pacman -Syu --noconfirm && \
     pacman -S --noconfirm \
+    ca-certificates \
     python \
     python-pip \
     python-virtualenv \
     tmux \
     git \
     gdb \
-    gcc \
     make \
     curl \
     wget \
+    xz \
     vim && \
     git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && \
     ~/.fzf/install --all
 
-ENV PATH="/root/.fzf/bin:/root/.local/bin:${PATH}"
+RUN set -eux; \
+    case "$(uname -m)" in \
+        x86_64) zig_arch=x86_64-linux ;; \
+        aarch64) zig_arch=aarch64-linux ;; \
+        *) echo "Unsupported Zig host architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zig_arch}-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz; \
+    mkdir -p /opt/zig; \
+    tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; \
+    rm /tmp/zig.tar.xz; \
+    /opt/zig/zig version
+
+ENV PATH="/opt/zig:/root/.fzf/bin:/root/.local/bin:${PATH}"
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.13 /uv /bin/
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "GEP development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          inherit (pkgs) lib stdenv;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              fzf
+              gnumake
+              shellcheck
+              shfmt
+              uv
+              tmux
+              gdb
+              zig_0_16
+            ];
+
+            shellHook = ''
+              echo "GEP development shell"
+              echo "  setup: uv sync --group dev"
+              echo "  lint:  ./lint.sh"
+              echo "  test:  ./tests.sh"
+              echo "  run:   gdb -q -ex 'source ./gdbinit-gep.py'"
+            '';
+          };
+        }
+      );
+    };
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,12 +88,23 @@ class GDBSession:
         Initialize the GDB session.
         """
         self.tmpdir = tempfile.TemporaryDirectory(prefix="gep_test_")
+        self.tmux_socket_path = str(Path(self.tmpdir.name) / "tmux.sock")
         with (Path(self.tmpdir.name) / GDBINIT_NAME).open("w") as f:
             f.write("set pagination off\n")
             f.write(f"source {GDBINIT_GEP_PY_PATH.resolve()}\n")
 
         self.session_name = None
         self.__session_started = False
+
+    def tmux_cmd(self, args: list[str]) -> list[str]:
+        """
+        Return a tmux command using this session's isolated server socket.
+
+        :param list[str] args: The arguments to pass to tmux.
+        :return: The full tmux command.
+        :rtype: list[str]
+        """
+        return ["tmux", "-S", self.tmux_socket_path, *args]
 
     def start(self, gdb_args: list[str] | None = None, histories: list[str] = None) -> None:
         """
@@ -109,23 +120,24 @@ class GDBSession:
                 f.write("\n".join(histories))
         gdbinit_path = Path(self.tmpdir.name) / GDBINIT_NAME
 
-        cmd = [
-            "tmux",
-            "-f",
-            os.devnull,
-            "new-session",
-            "-d",
-            "-P",
-            "-F",
-            "#{session_name}",
-            "-c",
-            self.tmpdir.name,
-            "gdb",
-            "-q",
-            "--nx",
-            "-ix",
-            str(gdbinit_path.resolve()),
-        ]
+        cmd = self.tmux_cmd(
+            [
+                "-f",
+                os.devnull,
+                "new-session",
+                "-d",
+                "-P",
+                "-F",
+                "#{session_name}",
+                "-c",
+                self.tmpdir.name,
+                "gdb",
+                "-q",
+                "--nx",
+                "-ix",
+                str(gdbinit_path.resolve()),
+            ]
+        )
         if gdb_args:
             cmd.extend(gdb_args)
 
@@ -152,21 +164,32 @@ class GDBSession:
         """
         if not self.__session_started:
             return
-        pid = subprocess.check_output(
-            [
-                "tmux",
-                "list-panes",
-                "-t",
-                self.session_name,
-                "-F",
-                "#{pane_pid}",
-            ],
-            text=True,
-        ).strip()
-        if pid:
-            os.kill(int(pid), signal.SIGTERM)
-        subprocess.run(["tmux", "kill-session", "-t", self.session_name])
-        self.__session_started = False
+        try:
+            try:
+                pid = subprocess.check_output(
+                    self.tmux_cmd(
+                        [
+                            "list-panes",
+                            "-t",
+                            self.session_name,
+                            "-F",
+                            "#{pane_pid}",
+                        ]
+                    ),
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                ).strip()
+            except subprocess.CalledProcessError:
+                pid = ""
+            if pid:
+                os.kill(int(pid), signal.SIGTERM)
+        finally:
+            subprocess.run(
+                self.tmux_cmd(["kill-server"]),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            self.__session_started = False
 
     def exit(self) -> None:
         """
@@ -203,7 +226,9 @@ class GDBSession:
         :param str literal: The literal string to send to the GDB session.
         :return: None
         """
-        run_with_screen_256color(["tmux", "send-keys", "-l", "-t", self.session_name, literal])
+        run_with_screen_256color(
+            self.tmux_cmd(["send-keys", "-l", "-t", self.session_name, literal])
+        )
         time.sleep(TIME_INTERVAL)
 
     @check_session_started
@@ -214,7 +239,7 @@ class GDBSession:
         :param str key: The key to send to the GDB session.
         :return: None
         """
-        run_with_screen_256color(["tmux", "send-keys", "-t", self.session_name, key])
+        run_with_screen_256color(self.tmux_cmd(["send-keys", "-t", self.session_name, key]))
         time.sleep(TIME_INTERVAL)
 
     @check_session_started
@@ -225,9 +250,9 @@ class GDBSession:
         :return: None
         :rtype: None
         """
-        run_with_screen_256color(["tmux", "send-keys", "-t", self.session_name, "C-l"])
+        run_with_screen_256color(self.tmux_cmd(["send-keys", "-t", self.session_name, "C-l"]))
         time.sleep(TIME_INTERVAL)
-        run_with_screen_256color(["tmux", "clear-history", "-t", self.session_name])
+        run_with_screen_256color(self.tmux_cmd(["clear-history", "-t", self.session_name]))
 
     @check_session_started
     def capture_pane(self, with_color: bool = False) -> bytes:
@@ -238,7 +263,7 @@ class GDBSession:
         :return: The content of the pane.
         :rtype: bytes
         """
-        cmd = ["tmux", "capture-pane", "-p", "-t", self.session_name]
+        cmd = self.tmux_cmd(["capture-pane", "-p", "-t", self.session_name])
         if with_color:
             cmd.append("-e")
         return run_with_screen_256color(cmd, capture_output=True).stdout.rstrip(b"\n")

--- a/tests/fixtures/Makefile
+++ b/tests/fixtures/Makefile
@@ -1,7 +1,9 @@
-CC = gcc
-CXX = g++
-CFLAGS = -g -O0
-CXXFLAGS = -g -O0
+CC = zig cc
+CXX = zig cc
+TARGET = x86_64-linux-musl
+CFLAGS = -target $(TARGET) -static -g -O0
+# Workaround for: https://codeberg.org/ziglang/zig/issues/32132
+CXXFLAGS = -x c++ -target $(TARGET) -static -g -O0
 
 all: test_program test_program_cpp
 

--- a/tests/fixtures/test_program_cpp.cc
+++ b/tests/fixtures/test_program_cpp.cc
@@ -1,4 +1,4 @@
-#include <cstdio>
+#include <stdio.h>
 
 namespace foo {
     class B {

--- a/tests/test_fzf_breakpoint.py
+++ b/tests/test_fzf_breakpoint.py
@@ -1,8 +1,15 @@
+import sys
+
+import pytest
 from conftest import TEST_PROGRAM_C
 from conftest import Breakpoint
 from conftest import Fzf
 from conftest import GDBSession
 from conftest import MacOSKeys
+
+skip_start_on_macos = pytest.mark.skipif(
+    sys.platform == "darwin", reason="Skipping tests that start the inferior on macOS"
+)
 
 
 class TestToggleDeleteFunctionality:
@@ -209,6 +216,7 @@ class TestFzfVisualization:
         pane_content = gdb_session.capture_pane()
         assert b"global_var" in pane_content
 
+    @skip_start_on_macos
     def test_format_read_watchpoint(self, gdb_session: GDBSession) -> None:
         gdb_session.start(gdb_args=[TEST_PROGRAM_C, "-ex", "start", "-ex", "rwatch global_var"])
         gdb_session.clear_pane()
@@ -217,6 +225,7 @@ class TestFzfVisualization:
         pane_content = gdb_session.capture_pane()
         assert b"global_var" in pane_content
 
+    @skip_start_on_macos
     def test_format_access_watchpoint(self, gdb_session: GDBSession) -> None:
         gdb_session.start(gdb_args=[TEST_PROGRAM_C, "-ex", "start", "-ex", "awatch global_var"])
         gdb_session.clear_pane()
@@ -225,6 +234,7 @@ class TestFzfVisualization:
         pane_content = gdb_session.capture_pane()
         assert b"global_var" in pane_content
 
+    @skip_start_on_macos
     def test_format_catchpoint(self, gdb_session: GDBSession) -> None:
         gdb_session.start(gdb_args=[TEST_PROGRAM_C, "-ex", "catch syscall write"])
         gdb_session.clear_pane()
@@ -283,6 +293,7 @@ class TestPreviewInformation:
         pane_content = gdb_session.capture_pane()
         assert b"Expression:" in pane_content
 
+    @skip_start_on_macos
     def test_shows_what_for_catchpoint(self, gdb_session: GDBSession) -> None:
         gdb_session.start(gdb_args=[TEST_PROGRAM_C, "-ex", "catch syscall write"])
         gdb_session.clear_pane()
@@ -349,6 +360,7 @@ class TestPreviewInformation:
         assert b"Type:" in pane_content
         assert b"watchpoint" in pane_content
 
+    @skip_start_on_macos
     def test_shows_type_for_catchpoint(self, gdb_session: GDBSession) -> None:
         gdb_session.start(gdb_args=[TEST_PROGRAM_C, "-ex", "catch syscall write"])
         gdb_session.clear_pane()

--- a/tests/test_fzf_tab_completion.py
+++ b/tests/test_fzf_tab_completion.py
@@ -154,9 +154,9 @@ def test_fzf_tab_quoted_symbol_completion(gdb_session: GDBSession) -> None:
     This tests the bug handling quoted symbols for commands like 'b' and 'p'.
     """
     gdb_session.start(gdb_args=[TEST_PROGRAM_C])
-    gdb_session.send_literal("b 'm")
+    gdb_session.send_literal("b 'ma")
     gdb_session.send_key("Tab")
-    gdb_session.send_literal("ain")
+    gdb_session.send_literal("in")
     gdb_session.send_key("Enter")
     pane_content = gdb_session.capture_pane()
     assert b"(gdb) b 'main'" == pane_content
@@ -165,9 +165,9 @@ def test_fzf_tab_quoted_symbol_completion(gdb_session: GDBSession) -> None:
     gdb_session.send_key("C-c")
     gdb_session.clear_pane()
 
-    gdb_session.send_literal("p 'm")
+    gdb_session.send_literal("p 'ma")
     gdb_session.send_key("Tab")
-    gdb_session.send_literal("ain")
+    gdb_session.send_literal("in")
     gdb_session.send_key("Enter")
     pane_content = gdb_session.capture_pane()
     assert b"(gdb) p 'main'" == pane_content


### PR DESCRIPTION
This PR improves the local host development workflow and test infrastructure.

- Add a Nix flake development shell so we can develop on the host without relying on the Docker environment. (Note: this is a lightweight dev shell; Python deps still use `uv`, so it can be made more idiomatic Nix later, if necessary.)
- Install Zig in Docker images and use Zig to build static x86_64 Linux fixture binaries. (This avoids macOS-specific debug symbol differences that can break tests relying on symbol information.)
- Skip some tests on macOS that rely on unsupported GDB behavior.
- Isolate tmux-based GDB tests with a per-test tmux socket so tests do not interact with the host tmux server.